### PR TITLE
[fix] MessageService Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# v0.3.1 - Released January 28, 2018
+# [0.3.2](https://github.com/bcorbold/MobileServerFrontEnd/) (TBD)
+- `MessageService` now will only emit changes for batchUpdates and orderHistory if there is a change to the respective caches 
+
+# [0.3.1](https://github.com/bcorbold/MobileServerFrontEnd/tree/0.3.1) (28-01-2018)
 - Increased polling rate for order history and batch updates
 
-# v0.3.0 - Released January 28, 2018
+# [0.3.0](https://github.com/bcorbold/MobileServerFrontEnd/tree/0.3.0) (28-01-2018)
 - Removed mock data from UI project. Connected backend API calls so that data is now returned from the backend
 - Restyle application for a more "flat" layout


### PR DESCRIPTION
- `MessageService` now will only emit changes for batchUpdates and orderHistory if there is a change to the respective caches